### PR TITLE
fix(types): rewrite enums to regular types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,38 +1,37 @@
 import { ComponentType, Ref, RefForwardingComponent } from 'react';
 import JQuery = require('jquery');
 
-export enum Locale {
-  en = 'en',
-  ar = 'ar',
-  az = 'az',
-  ca = 'ca',
-  cs = 'cs',
-  da = 'da',
-  de = 'de',
-  el = 'el',
-  es = 'es',
-  et = 'et',
-  fr = 'fr',
-  he = 'he',
-  it = 'it',
-  ja = 'ja',
-  ko = 'ko',
-  lv = 'lv',
-  nb = 'nb',
-  nl = 'nl',
-  pl = 'pl',
-  pt = 'pt',
-  ro = 'ro',
-  ru = 'ru',
-  sk = 'sk',
-  sr = 'sr',
-  sv = 'sv',
-  tr = 'tr',
-  uk = 'uk',
-  vi = 'vi',
-  zhTW = 'zhTW',
-  zh = 'zh',
-}
+export type Locale =
+  'en' |
+  'ar' |
+  'az' |
+  'ca' |
+  'cs' |
+  'da' |
+  'de' |
+  'el' |
+  'es' |
+  'et' |
+  'fr' |
+  'he' |
+  'it' |
+  'ja' |
+  'ko' |
+  'lv' |
+  'nb' |
+  'nl' |
+  'pl' |
+  'pt' |
+  'ro' |
+  'ru' |
+  'sk' |
+  'sr' |
+  'sv' |
+  'tr' |
+  'uk' |
+  'vi' |
+  'zhTW' |
+  'zh';
 
 export type LocalePluralize = (n: number) => string;
 
@@ -243,12 +242,6 @@ export interface DialogApi {
   onTabVisibility(callback: OnTabVisibilityCallback): void;
 }
 
-export enum Crop {
-  Disabled = 'disabled',
-  Free = 'free',
-  Default = ''
-}
-
 export interface Settings {
   // developer hooks
   locale?: Locale;
@@ -256,7 +249,7 @@ export interface Settings {
   localeTranslations?: LocaleTranslations;
   // widget & dialog settings
   systemDialog?: boolean;
-  crop?: Crop | string;
+  crop?: string;
   previewStep?: boolean;
   imagesOnly?: boolean;
   clearable?: boolean;

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -1,24 +1,16 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Widget, CustomTabConstructor, FileInfo, WidgetAPI, Locale, Crop } from '@uploadcare/react-widget';
+import { Widget, CustomTabConstructor, FileInfo, WidgetAPI } from '@uploadcare/react-widget';
 
 <Widget publicKey='demopublickey' />;
 
 <Widget
   publicKey='demopublickey'
-  locale={Locale.de} />;
+  locale='de' />;
 
 <Widget
   publicKey='demopublickey'
-  crop={Crop.Disabled} />;
-
-<Widget
-  publicKey='demopublickey'
-  crop={Crop.Free} />;
-
-<Widget
-  publicKey='demopublickey'
-  crop={Crop.Default} />;
+  crop='disabled' />;
 
 <Widget
   publicKey='demopublickey'


### PR DESCRIPTION
enums without const waits that plain js objects will be exported:
[playground](https://www.typescriptlang.org/play/#code/KYDwDg9gTgLgBMAdgVwLZwDIQMYEMA2wcA3gFBwKJwC8cA5EnQDTly5Q33vOu4BenOvx4U8gvCLjYAzuOmSAJrkFLFRWnQXBJwfIN07ZG4PJYVg8YzEkAzDhruSAFuvovJAS0v0vkgFbKGgGSANYQgmGS+ABugjGSiABGgkkJehqI+JJg6fQ52d50YNZmcFDhGuWSUMiCNZLSIYKNDfb00lANsRrS0ZIwbXQDkshNGqOS0R6CU5J8TgAqAOqC88tzTqtOPAC+QA)

const enums is bad: 
[no const enum](https://github.com/Microsoft/dtslint/blob/master/docs/no-const-enum.md)


because of that i just replace enums with regular values type