### PR TITLE
Allow null type for `preloader` prop

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -338,7 +338,6 @@ declare const Widget: RefForwardingComponent<{
   locale?: Locale;
   localeTranslations?: LocaleTranslations;
   localePluralize?: LocalePluralize;
-  preloader?: string;
 }, WidgetProps>;
 
 export {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -319,7 +319,7 @@ interface WidgetProps extends Settings {
   onFileSelect?: (fileInfo: FileInfo) => void;
   customTabs?: {[key: string]: CustomTabConstructor};
   validators?: Validator[];
-  preloader?: ComponentType;
+  preloader?: ComponentType | null;
   ref?: Ref<WidgetAPI>;
 }
 

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -64,6 +64,10 @@ const Preloader = () => <div />;
   publicKey='demopublickey'
   preloader={Preloader}/>;
 
+<Widget
+  publicKey='demopublickey'
+  preloader={null}/>;
+
 const widgetApi = React.useRef<WidgetAPI>(null);
 
 <Widget ref={widgetApi} publicKey='demopublickey' />;


### PR DESCRIPTION
Fixes https://github.com/uploadcare/react-widget/issues/112