### PR TITLE
chore: skip @rollup/commonjs update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,5 +8,6 @@
       "updateTypes": ["patch", "minor"],
       "groupName": "dev dependencies (non-major)"
     }
-  ]
+  ],
+  "ignoreDeps": ["@rollup/plugin-commonjs"]
 }


### PR DESCRIPTION
## Description

Skip updating `@rollup/commonjs` because  https://github.com/rollup/plugins/issues/304
