### PR TITLE
fix: use another plugin for module replacement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17738,6 +17738,23 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "rollup-plugin-module-replacement": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-module-replacement/-/rollup-plugin-module-replacement-1.1.0.tgz",
+      "integrity": "sha512-5zVj5njXrjM7bma/PNh8oQTuEJfrF0PIv9caxAIX9HCFqVY4KJjaR4SXHPj79Gb18BClF8NdqddZYPG/I2MtkA==",
+      "dev": true,
+      "requires": {
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
+      }
+    },
     "rollup-pluginutils": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "rimraf": "3.0.2",
     "rollup": "2.10.0",
     "rollup-plugin-babel": "4.4.0",
+    "rollup-plugin-module-replacement": "1.1.0",
     "shipjs": "0.19.0",
     "typescript": "3.9.2",
     "uploadcare-widget-tab-effects": "1.4.6"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import babel from 'rollup-plugin-babel'
 import commonjs from '@rollup/plugin-commonjs'
 import replace from '@rollup/plugin-replace'
+import replacement from 'rollup-plugin-module-replacement'
 
 import uploadcare from 'uploadcare-widget'
 
@@ -72,7 +73,14 @@ export default [
       sourcemap: false
     },
     plugins: [
-      replace({ 'uploadcare-widget': 'uploadcare-widget/uploadcare.lang.en' }),
+      replacement({
+        entries: [
+          {
+            find: 'uploadcare-widget',
+            replacement: 'uploadcare-widget/uploadcare.lang.en'
+          }
+        ]
+      }),
       commonjs({
         include: /node_modules/,
         sourceMap: false


### PR DESCRIPTION
Use another plugin for module replacement because `@rollup/plugin-replace` runs twice and breaks `en` bundle

re #153

## Checklist

- [ ] Tests (if applicable)
