### PR TITLE
fix: use `annotate-pure-calls` instead of direct `#__pure` notations

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-react"]
+  "presets": ["@babel/preset-react"],
+  "plugins": ["annotate-pure-calls"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5791,6 +5791,12 @@
         }
       }
     },
+    "babel-plugin-annotate-pure-calls": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.4.0.tgz",
+      "integrity": "sha512-oi4M/PWUJOU9ZyRGoPTfPMqdyMp06jbJAomd3RcyYuzUtBOddv98BqLm96Lucpi2QFoQHkdGQt0ACvw7VzVEQA==",
+      "dev": true
+    },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "types/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "lint:types": "dtslint types --onlyTestTsNext",
     "lint:js": "eslint ./src/** ./test/** rollup.config.js",
@@ -71,6 +72,7 @@
     "@types/jquery": "3.3.38",
     "@types/react": "16.9.35",
     "babel-eslint": "10.1.0",
+    "babel-plugin-annotate-pure-calls": "^0.4.0",
     "dtslint": "3.5.2",
     "eslint": "7.0.0",
     "eslint-config-prettier": "6.11.0",

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,11 @@ import React, { forwardRef } from 'react'
 import { lazy, Suspense } from '@uploadcare/client-suspense'
 import { useIsomorphicEffect } from './hooks'
 
-// enable tree shaking with pure notation
-const Uploader = /* #__PURE__ */lazy(() =>
+const Uploader = lazy(() =>
   import(/* webpackChunkName: "ucare-widget-chunk" */ './uploader')
 )
 
-// enable tree shaking with pure notation
-const Dialog = /* #__PURE__ */lazy(() =>
+const Dialog = lazy(() =>
   import(/* webpackChunkName: "ucare-panel-chunk" */ './dialog')
 )
 


### PR DESCRIPTION
use `annotate-pure-calls` instead of direct `#__pure` notations and mark module as side effect free

## Checklist

- [ ] Tests (if applicable)
