### PR TITLE
feat: support tabsCss property

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ const Example = () => {
 
 <br>
 
+#### `tabsCss: string`
+
+Optionally define custom css for tabs opened in iframes (e.g. Facebook, Instagram, etc.). Can be a css string or an absolute file URL.
+
+```jsx
+// Via URL
+<Widget tabs="facebook" tabsCss="https://site.com/styles/uc.tabs.css"/>
+
+// Via plain CSS
+<Widget tabs="facebook" tabsCss=".source-facebook { background: #1877F2; }"/>
+```
+
+Note that all tab iframes are opened via HTTPS, so linked CSS files must also be served via HTTPS.
+
+* [Widget styling docs][uc-docs-widget-styling]
+
+<br>
+
 ### Widget configuration
 
 Uploadcare Widget can be deeply customized to suit your UX/UI. You can define
@@ -232,6 +250,7 @@ request at [hello@uploadcare.com][uc-email-hello].
 [uc-feature-widget]: https://uploadcare.com/features/widget/?utm_source=github&utm_campaign=react-widget
 [uc-docs-widget-config]: https://uploadcare.com/docs/uploads/widget/config/?utm_source=github&utm_campaign=react-widget
 [uc-docs-widget-js-api]: https://uploadcare.com/docs/api_reference/javascript/?utm_source=github&utm_campaign=react-widget
+[uc-docs-widget-styling]: https://uploadcare.com/docs/file_uploader_api/tabs_styling/
 [uc-sign-up]: https://uploadcare.com/accounts/signup/
 [uc-docs-groups]: https://uploadcare.com/docs/delivery/group_api/#groups
 [uc-docs-files]: https://uploadcare.com/docs/concepts/#uploads

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -33,7 +33,7 @@ const useDialog = (props, uploadcare) => {
     progress: null
   })
 
-  const { customTabs } = props
+  const { customTabs, tabsCss } = props
 
   useCustomTabs(customTabs, uploadcare)
 
@@ -42,6 +42,14 @@ const useDialog = (props, uploadcare) => {
 
   useEffect(() => {
     if (state.opened) {
+      if (uploadcare && tabsCss && typeof tabsCss === 'string') {
+        if (tabsCss.indexOf('https://') === 0) {
+          uploadcare.tabsCss.addUrl(tabsCss)
+        } else {
+          uploadcare.tabsCss.addStyle(tabsCss)
+        }
+      }
+
       panelInstance.current && panelInstance.current.reject()
       panelInstance.current = uploadcare.openPanel(
         panelContainer.current,

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -36,6 +36,7 @@ const useWidget = (
     apiRef,
     customTabs,
     validators,
+    tabsCss,
     ...options
   },
   uploadcare
@@ -102,6 +103,16 @@ const useWidget = (
   useEffect(() => {
     widget.current.value(value)
   }, [value])
+
+  useEffect(() => {
+    if (uploadcare && tabsCss && typeof tabsCss === 'string') {
+      if (tabsCss.indexOf('https://') === 0) {
+        uploadcare.tabsCss.addUrl(tabsCss)
+      } else {
+        uploadcare.tabsCss.addStyle(tabsCss)
+      }
+    }
+  }, [uploadcare, tabsCss])
 
   useImperativeHandle(
     apiRef,


### PR DESCRIPTION
## Description

The file uploader currently supports passing in custom CSS for iframe tabs (e.g. Instagram, Facebook, etc), yet I didn't see any clear way of doing so through _react-widget_. This can now be accomplished for both the `Widget` and `Dialog` components via the `tabsCss` property. The value passed in can be either a CSS string or an absolute file URL.

```jsx
// Via URL
<Widget tabs="facebook" tabsCss="https://site.com/styles/uc.tabs.css"/>

// Via plain CSS
<Widget tabs="facebook" tabsCss=".source-facebook { background: #1877F2; }"/>
```
**Resulting widget**
![Screen Shot 2020-07-23 at 4 48 10 PM](https://user-images.githubusercontent.com/942003/88337506-d4aea500-cd04-11ea-950d-760dfababc5d.png)

## Checklist

- [x] ~Tests (if applicable)~
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
