### PR TITLE
fix(uploader): replace IE unsupported ChildNode.remove method

### DIFF
--- a/src/uploader.js
+++ b/src/uploader.js
@@ -61,7 +61,7 @@ const useWidget = (
     widget.current = uploadcare.Widget(input.current)
     const widgetElement = input.current.nextSibling
 
-    return () => widgetElement && widgetElement.remove()
+    return () => widgetElement && widgetElement.parentNode.removeChild(widgetElement)
   }, [uploadcare, attributes])
 
   useValidators(widget, validators)


### PR DESCRIPTION
## Description
The ChildNode.remove method is unsupported in IE, causing crashes when react-widget unmounts.

Fixed by using the common alternative `element.parentNode.removeChild(element)`.
<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist
- [x] ~Tests (if applicable)~
- [x] ~Documentation (if applicable)~
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
