### PR TITLE
fix(types): export file upload types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+* **types** Export types FileUpload and FilesUpload.
+
 ## [1.3.5](https://github.com/uploadcare/react-widget/compare/v1.3.4...v1.3.5) (2021-02-26)
 
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -365,6 +365,8 @@ export {
   Uuid,
   SourceInfo,
   FileInfo,
+  FileUpload,
+  FilesUpload,
   DialogApi,
   OnTabVisibilityCallback,
   Settings,


### PR DESCRIPTION

## Description

Export types FileUpload and FilesUpload.

If you are using typescript, these two types are needed to properly
type the callbacks: onFileSelect, onDialogClose

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->
```javascript

// These types currently aren't exported
import type { FileUpload, FilesUpload } from '@uploadcare/react-widget';
import { Widget } from '@uploadcare/react-widget';

// So you can't type these callbacks
const  onFileSelect = (fileInfo: FileUpload | FilesUpload | null):void => {
  ...
};
const  onDialogClose = (fileInfo: FileUpload | FilesUpload | null):void => {
  ...
};

<Widget
  onFileSelect={onFileSelect}
  onDialogClose={onDialogClose}
 ... 
/>
```


## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
