### PR TITLE
Typescript patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Bug Fixes
 
 * **types** Export types FileUpload and FilesUpload.
+* **types** FileInfo type updated to account for null uuid and mime-type during validation callback
+* **types** Fix the type of the fileColl attibute of the dialog api
+* **types** Add and export the FileGroup type
 
 ## [1.3.5](https://github.com/uploadcare/react-widget/compare/v1.3.4...v1.3.5) (2021-02-26)
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -373,8 +373,10 @@ interface FileUpload extends JQuery.Deferred<FileInfo> {
   uuid: string;
 }
 
+interface FileGroupUpload extends JQuery.Deferred<FileGroup> { }
+
 interface FilesUpload {
-  promise: () => FileGroup;
+  promise: () => FileGroupUpload;
   files: () => FileUpload[];
 }
 
@@ -416,6 +418,7 @@ export {
   SourceInfo,
   FileInfo,
   FileGroup,
+  FileGroupUpload,
   FileUpload,
   FilesUpload,
   DialogApi,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -231,13 +231,13 @@ interface SourceInfo {
 }
 
 interface FileInfo {
-  uuid: Uuid;
+  uuid: null | Uuid;
   name: null | string;
   size: null | number;
   isStored: null | boolean;
   isImage: null | boolean;
   originalImageInfo: null | OriginalImageInfo;
-  mimeType: string;
+  mimeType: null | string;
   originalUrl: null | string;
   cdnUrl: null | string;
   cdnUrlModifiers: null | string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -355,8 +355,26 @@ interface WidgetAPI {
 interface FileUpload extends JQuery.Deferred<FileInfo> {
   cancel: () => FileUpload;
 }
+
+/**
+ * The result of uploading multiple files to upload care is a file group.
+ *
+ * The react upload care widget does not (yet) define this type.
+ *
+ * This type is reverse engineered from stepping into the debugger.
+ */
+ interface FileGroup {
+  cdnUrl: string;
+  count: number;
+  isImage: boolean;
+  isStored: boolean;
+  name: string;
+  size: number;
+  uuid: string;
+}
+
 interface FilesUpload {
-  promise: () => FileUpload;
+  promise: () => FileGroup;
   files: () => FileUpload[];
 }
 
@@ -397,6 +415,7 @@ export {
   Uuid,
   SourceInfo,
   FileInfo,
+  FileGroup,
   FileUpload,
   FilesUpload,
   DialogApi,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -252,10 +252,40 @@ interface FileInfo {
 
 type OnTabVisibilityCallback = (tab: string, shown: boolean) => void;
 
+interface Collection<T> {
+  onAdd: JQuery.Callbacks;
+  onRemove: JQuery.Callbacks;
+  onSort: JQuery.Callbacks;
+  onReplace: JQuery.Callbacks;
+  __items: T[];
+
+  add: (item: T) => JQuery.Callbacks | undefined;
+  remove: (item: T) => JQuery.Callbacks | undefined;
+  clear: () => JQuery.Callbacks[];
+  replace: (oldItem: T, newItem: T) => JQuery.Callbacks | undefined;
+  sort: (comparator: (a: T, b: T) => boolean) => JQuery.Callbacks;
+  get: (index: number) => T;
+  length: () => number;
+}
+
+interface UniqCollection<T> extends Collection<T> {
+  add: (item: T) => JQuery.Callbacks | undefined;
+}
+interface CollectionOfPromises<T> extends UniqCollection<JQuery.Deferred<T>> {
+  anyDoneList: JQuery.Callbacks;
+  anyFailList: JQuery.Callbacks;
+  anyProgressList: JQuery.Callbacks;
+
+  onAnyDone: unknown;
+  onAnyFail: unknown;
+  onAnyProgress: unknown;
+  lastProgresses: unknown;
+  autoThen: unknown;
+}
 interface DialogApi {
   addFiles(files: FileInfo[]): void;
   switchTab(tab: string): void;
-  fileColl: FileInfo[];
+  fileColl: CollectionOfPromises<FileInfo>;
   hideTab(tab: string): void;
   showTab(tab: string): void;
   isTabVisible(tab: string): boolean;
@@ -322,7 +352,9 @@ interface WidgetAPI {
   getInput: () => HTMLInputElement;
 }
 
-type FileUpload = JQuery.Deferred<FileInfo>;
+interface FileUpload extends JQuery.Deferred<FileInfo> {
+  cancel: () => FileUpload;
+}
 interface FilesUpload {
   promise: () => FileUpload;
   files: () => FileUpload[];


### PR DESCRIPTION
## Description

PR for https://github.com/uploadcare/react-widget/issues/253

This fixes a few of issues with the type definitions in this project.  I inferred most of these fixes by debugging and reverse engineering the types.

A couple notable ones:

- FileInfo: the uuid/mimeType can both be null for new files when the validator is invoked
- The dialog API fileColl typing is wrong. In general with the existing type defs it looks like there is confusing between what is a FileInfo and what is a FileUpload.
- The FileGroup type was missing.

Without the types being exported, its hard to write typed functions, so FileGroup is now exported

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
