### PR TITLE
fix(types): `openDialog()` could accept optional argument of string, null or `Settings` type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -368,7 +368,7 @@ interface Settings extends LocaleSettings {
 }
 
 interface WidgetAPI {
-  openDialog: (tab: string) => void;
+  openDialog: (tab?: string | null | Settings) => void;
   reloadInfo: () => void;
   getInput: () => HTMLInputElement;
   value: (value?: null | string[] | JQuery.Deferred<FileInfo> | JQuery.Deferred<FileGroup>) => void;


### PR DESCRIPTION
Fixes https://github.com/uploadcare/react-widget/issues/348

Checks will be ok after https://github.com/uploadcare/react-widget/pull/347 merge