### PR TITLE
Feat/metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,28 @@ Set a function to be called after **tab is changed**.
 
 <br>
 
+#### `metadata: (metadata: Record<string, string>)`
+
+The option can be used to set metadata object associated with the uploaded file.
+
+Note that metadata supports `string` values only, any non-string value will be converted to `string`, including `boolean`, `number`, `null` and `undefined`.
+
+See [Metadata docs][uc-docs-metadata] for details.
+
+<br>
+
+#### `metadataCallback: () => Record<string, string>`
+
+Defines the function that specifies the actual metadata object a file uploader should use to associate with the uploaded file. It's helpful in the case of dynamic metadata object.
+
+If this option is specified, option `metadata` will be overridden (without merging).
+
+Note that metadata supports `string` values only, any non-string value will be converted to `string`, including `boolean`, `number`, `null` and `undefined`.
+
+See [Metadata docs][uc-docs-metadata] for details.
+
+<br>
+
 #### `customTabs: {[key: string]: CustomTabConstructor}`
 
 Add **custom tabs** for a widget.
@@ -387,6 +409,7 @@ We want to hear your issue reports and feature requests at
 [uc-docs-widget-single-file-value]: https://uploadcare.com/docs/file-uploader-api/widget/#single-file-value
 [uc-docs-widget-open-dialog]: https://uploadcare.com/docs/file-uploader-api/widget/#widget-open-dialog
 [uc-docs-widget-reload-info]: https://uploadcare.com/docs/file-uploader-api/widget/#widget-reload-info
+[uc-docs-metadata]: https://uploadcare.com/docs/file-metadata/
 
 [sandbox-simple-demo]: https://codesandbox.io/s/uploadcarereact-widget-7xpqp
 [sandbox-props]: https://codesandbox.io/s/uploadcarereact-widget-props-example-oqk0v

--- a/dummy/app.js
+++ b/dummy/app.js
@@ -6,6 +6,8 @@ import Callbacks from './dialog-callbacks'
 import Panel from './default-panel'
 import WidgetWithEffects from './widget-with-effects'
 import PanelWithEffects from './panel-with-effects'
+import PanelMetadata from './panel-metadata'
+import WidgetMetadata from './widget-metadata'
 import Crop from './crop'
 
 const Example = ({ text, component: Component }) => (
@@ -45,6 +47,14 @@ const examples = [
   {
     text: 'Panel with effects',
     component: PanelWithEffects
+  },
+  {
+    text: 'Panel with metadata',
+    component: PanelMetadata
+  },
+  {
+    text: 'Widget with metadata',
+    component: WidgetMetadata
   }
 ]
 

--- a/dummy/panel-metadata.js
+++ b/dummy/panel-metadata.js
@@ -1,0 +1,19 @@
+
+import React from 'react'
+
+import { Panel } from '../src'
+
+export default () => {
+  return (
+    <Panel
+      publicKey="demopublickey"
+      onChange={(files) => {
+        Promise.allSettled(files).then((results) =>
+          console.log('onChange', results)
+        )
+      }}
+      // metadata={{metadata: 'metadata'}}
+      metadataCallback={() => ({metadataCallback: 'metadataCallback'})}
+    />
+  )
+}

--- a/dummy/widget-metadata.js
+++ b/dummy/widget-metadata.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Widget } from '../src'
+
+export default () => {
+  return (
+    <Widget
+      publicKey='demopublickey'
+      previewStep
+      onChange={file => console.log(file)}
+      // metadata={{metadata: 'metadata'}}
+      metadataCallback={() => ({metadataCallback: 'metadataCallback'})}
+    />
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/jquery-deferred": "^0.3.0",
         "@uploadcare/client-suspense": "^1.1.0",
         "react-fast-compare": "^3.2.0",
-        "uploadcare-widget": "^3.17.2"
+        "uploadcare-widget": "^3.20.1"
       },
       "devDependencies": {
         "@babel/cli": "7.17.6",
@@ -20835,9 +20835,9 @@
       }
     },
     "node_modules/uploadcare-widget": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/uploadcare-widget/-/uploadcare-widget-3.17.2.tgz",
-      "integrity": "sha512-A9fDKCguevWcFaMCrHROtYzwnMZbOozER6Dru+4zrZH1pP0S7zI/g+7wLv+5U4XZTc5m+4ZrwHrZJzkIRnWeMQ==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/uploadcare-widget/-/uploadcare-widget-3.20.1.tgz",
+      "integrity": "sha512-rrF7U/G8IBV12HSLpDa1gzuaPuLwtIBaALLy1lzl6BfEq5O1LtRN5S4MRn3NPHEUCj6TOBZTzu0vkhMatmvHwA==",
       "dependencies": {
         "escape-html": "^1.0.3",
         "jquery": "^3.6.0"
@@ -37877,9 +37877,9 @@
       "dev": true
     },
     "uploadcare-widget": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/uploadcare-widget/-/uploadcare-widget-3.17.2.tgz",
-      "integrity": "sha512-A9fDKCguevWcFaMCrHROtYzwnMZbOozER6Dru+4zrZH1pP0S7zI/g+7wLv+5U4XZTc5m+4ZrwHrZJzkIRnWeMQ==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/uploadcare-widget/-/uploadcare-widget-3.20.1.tgz",
+      "integrity": "sha512-rrF7U/G8IBV12HSLpDa1gzuaPuLwtIBaALLy1lzl6BfEq5O1LtRN5S4MRn3NPHEUCj6TOBZTzu0vkhMatmvHwA==",
       "requires": {
         "escape-html": "^1.0.3",
         "jquery": "^3.6.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@types/jquery-deferred": "^0.3.0",
     "@uploadcare/client-suspense": "^1.1.0",
     "react-fast-compare": "^3.2.0",
-    "uploadcare-widget": "^3.17.2"
+    "uploadcare-widget": "^3.20.1"
   },
   "peerDependencies": {
     "react": "^16.10.2 || ^17.0.0 || ^18.0.0",

--- a/src/default-preview-url-callback.js
+++ b/src/default-preview-url-callback.js
@@ -1,0 +1,1 @@
+export const defaultPreviewUrlCallback = (cdnUrl) => cdnUrl

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -6,7 +6,7 @@ import React, {
   useState
 } from 'react'
 import uploadcare from 'uploadcare-widget'
-import { useCustomTabs, useDeepEffect, useEventCallback } from './hooks'
+import { useCustomTabs, useDeepEffect, useCommitedCallback } from './hooks'
 
 const containerStyles = {
   height: '500px',
@@ -47,9 +47,9 @@ const useDialog = (props, uploadcare) => {
   const panelContainer = useRef(null)
   const panelInstance = useRef(null)
 
-  const onTabChangeCallback = useEventCallback(onTabChange)
-  const onChangeCallback = useEventCallback(onChange)
-  const onProgressCallback = useEventCallback(onProgress)
+  const onTabChangeCallback = useCommitedCallback(onTabChange)
+  const onChangeCallback = useCommitedCallback(onChange)
+  const onProgressCallback = useCommitedCallback(onProgress)
 
   useCustomTabs(customTabs, uploadcare)
 

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -7,6 +7,7 @@ import React, {
 } from 'react'
 import uploadcare from 'uploadcare-widget'
 import { useCustomTabs, useDeepEffect, useCommitedCallback } from './hooks'
+import { defaultPreviewUrlCallback } from './default-preview-url-callback'
 
 const containerStyles = {
   height: '500px',
@@ -39,6 +40,8 @@ const useDialog = (props, uploadcare) => {
     onChange,
     onProgress,
     customTabs,
+    previewUrlCallback,
+    metadataCallback,
     ...restProps
   } = props
 
@@ -50,6 +53,11 @@ const useDialog = (props, uploadcare) => {
   const onTabChangeCallback = useCommitedCallback(onTabChange)
   const onChangeCallback = useCommitedCallback(onChange)
   const onProgressCallback = useCommitedCallback(onProgress)
+
+  const metadataCommitedCallback = useCommitedCallback(metadataCallback)
+  const previewUrlCommitedCallback = useCommitedCallback(
+    previewUrlCallback || defaultPreviewUrlCallback
+  )
 
   useCustomTabs(customTabs, uploadcare)
 
@@ -86,7 +94,9 @@ const useDialog = (props, uploadcare) => {
       {
         multipleMax: restProps.multiple ? undefined : 1,
         ...restProps,
-        multiple: true
+        multiple: true,
+        metadataCallback: metadataCommitedCallback,
+        previewUrlCallback: previewUrlCommitedCallback
       }
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,6 +1,6 @@
 export * from './use-commited-ref'
 export * from './use-destructuring'
-export * from './use-event-callback'
+export * from './use-commited-callback'
 export * from './use-state'
 export * from './use-custom-tabs'
 export * from './use-validators'

--- a/src/hooks/use-commited-callback.js
+++ b/src/hooks/use-commited-callback.js
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useCommitedRef } from './use-commited-ref'
 
-export const useEventCallback = (callback) => {
+export const useCommitedCallback = (callback) => {
   const ref = useCommitedRef(callback)
 
   return useCallback((...args) => ref.current && ref.current(...args), [ref])

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -7,7 +7,7 @@ import React, {
 import uploadcare from 'uploadcare-widget'
 
 import {
-  useEventCallback,
+  useCommitedCallback,
   useCustomTabs,
   useValidators,
   useDeepMemo,
@@ -53,11 +53,11 @@ const useWidget = (
   const widget = useRef(null)
   const cachedValueRef = useRef(null)
 
-  const fileSelectedCallback = useEventCallback(onFileSelect)
-  const changeCallback = useEventCallback(onChange)
-  const dialogOpenCallback = useEventCallback(onDialogOpen)
-  const dialogCloseCallback = useEventCallback(onDialogClose)
-  const tabChangeCallback = useEventCallback(onTabChange)
+  const fileSelectedCallback = useCommitedCallback(onFileSelect)
+  const changeCallback = useCommitedCallback(onChange)
+  const dialogOpenCallback = useCommitedCallback(onDialogOpen)
+  const dialogCloseCallback = useCommitedCallback(onDialogClose)
+  const tabChangeCallback = useCommitedCallback(onTabChange)
 
   useCustomTabs(customTabs, uploadcare)
 

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -1,31 +1,19 @@
 import React, {
-  useEffect,
-  useRef,
   useCallback,
-  useImperativeHandle
+  useEffect,
+  useImperativeHandle,
+  useRef
 } from 'react'
 import uploadcare from 'uploadcare-widget'
 
+import { defaultPreviewUrlCallback } from './default-preview-url-callback'
 import {
   useCommitedCallback,
   useCustomTabs,
-  useValidators,
+  useDeepEffect,
   useDeepMemo,
-  useDeepEffect
+  useValidators
 } from './hooks'
-
-function camelCaseToDash(str) {
-  return str.replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase()
-}
-
-const propsToAttr = (props) =>
-  Object.entries(props).reduce(
-    (attr, [key, value]) => ({
-      ...attr,
-      [`data-${camelCaseToDash(key)}`]: value
-    }),
-    {}
-  )
 
 const useWidget = (
   {
@@ -45,6 +33,7 @@ const useWidget = (
     localeTranslations,
     localePluralize,
     previewUrlCallback,
+    metadataCallback,
     ...options
   },
   uploadcare
@@ -59,18 +48,20 @@ const useWidget = (
   const dialogCloseCallback = useCommitedCallback(onDialogClose)
   const tabChangeCallback = useCommitedCallback(onTabChange)
 
-  useCustomTabs(customTabs, uploadcare)
+  const metadataCommitedCallback = useCommitedCallback(metadataCallback)
+  const previewUrlCommitedCallback = useCommitedCallback(
+    previewUrlCallback || defaultPreviewUrlCallback
+  )
 
-  const attributes = useDeepMemo(() => propsToAttr(options), [options])
+  const widgetOptions = useDeepMemo(() => options, [options])
+
+  useCustomTabs(customTabs, uploadcare)
 
   useDeepEffect(() => {
     if (locale) window.UPLOADCARE_LOCALE = locale
     if (localePluralize) window.UPLOADCARE_LOCALE_PLURALIZE = localePluralize
     if (localeTranslations) {
       window.UPLOADCARE_LOCALE_TRANSLATIONS = localeTranslations
-    }
-    if (previewUrlCallback) {
-      window.UPLOADCARE_PREVIEW_URL_CALLBACK = previewUrlCallback
     }
 
     uploadcare.plugin((internal) => {
@@ -85,13 +76,17 @@ const useWidget = (
       if (locale) delete window.UPLOADCARE_LOCALE
       if (localePluralize) delete window.UPLOADCARE_LOCALE_PLURALIZE
       if (localeTranslations) delete window.UPLOADCARE_LOCALE_TRANSLATIONS
-      if (previewUrlCallback) delete window.UPLOADCARE_PREVIEW_URL_CALLBACK
     }
-  }, [locale, localeTranslations, localePluralize, previewUrlCallback])
+  }, [locale, localeTranslations, localePluralize])
 
   useEffect(() => {
     const inputEl = input.current
-    widget.current = uploadcare.Widget(inputEl)
+    widget.current = uploadcare.Widget(inputEl, {
+      ...widgetOptions,
+      metadataCallback: metadataCommitedCallback,
+      previewUrlCallback: previewUrlCommitedCallback
+    })
+
     const widgetElement = inputEl.nextSibling
     if (cachedValueRef.current) {
       // restore widget value when called twice in React.StrictMode
@@ -106,7 +101,13 @@ const useWidget = (
       uploadcare.jQuery(inputEl).removeData('uploadcareWidget')
       widgetElement && widgetElement.remove()
     }
-  }, [uploadcare, attributes])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    uploadcare,
+    widgetOptions,
+    metadataCommitedCallback,
+    previewUrlCommitedCallback
+  ])
 
   useValidators(widget, validators)
 
@@ -118,7 +119,7 @@ const useWidget = (
       widget.current.onUploadComplete.remove(changeCallback)
       widget.current.onChange.remove(fileSelectedCallback)
     }
-  }, [changeCallback, fileSelectedCallback, uploadcare, attributes])
+  }, [changeCallback, fileSelectedCallback, uploadcare, widgetOptions])
 
   useEffect(() => {
     let dialog
@@ -138,7 +139,12 @@ const useWidget = (
       widget.current.onDialogOpen.remove(saveDialog)
       dialog && dialog.reject()
     }
-  }, [attributes, dialogCloseCallback, dialogOpenCallback, tabChangeCallback])
+  }, [
+    dialogCloseCallback,
+    dialogOpenCallback,
+    tabChangeCallback,
+    widgetOptions
+  ])
 
   useEffect(() => {
     let files = []
@@ -156,7 +162,7 @@ const useWidget = (
       files.forEach((file) => file.cancel())
       widget.current.onChange.remove(saveFiles)
     }
-  }, [attributes])
+  }, [widgetOptions])
 
   useEffect(() => {
     if (cachedValueRef.current !== value) {
@@ -187,10 +193,8 @@ const useWidget = (
   )
 
   return useCallback(
-    () => (
-      <input type="hidden" ref={input} id={id} name={name} {...attributes} />
-    ),
-    [attributes, id, name]
+    () => <input type="hidden" ref={input} id={id} name={name} />,
+    [id, name]
   )
 }
 


### PR DESCRIPTION
* Refactor `Widget` component - pass all the options through the Widget API instead of html attributes. This will allow us to pass metadata as an object instead of stringified JSON.
* Refactor `previewUrlCallback` option. Now we use local option key instead of global variable.

Related to #355 