### PR TITLE
fix: restore dialog callbacks after dialog re-initialization

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -137,7 +137,8 @@ const useDialog = (props, uploadcare) => {
       dialogApi.fileColl.onReplace.remove(onChangeWrapper)
       dialogApi.fileColl.onSort.remove(onChangeWrapper)
     }
-  }, [onTabChangeCallback, onChangeCallback, onProgressCallback])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...Object.values(restProps), onTabChangeCallback, onChangeCallback, onProgressCallback])
 
   useImperativeHandle(
     apiRef,


### PR DESCRIPTION
Fixes https://github.com/uploadcare/react-widget/issues/362